### PR TITLE
Fix postgres sequence name to return proper contact_id

### DIFF
--- a/SQL/postgres.initial.sql
+++ b/SQL/postgres.initial.sql
@@ -1,9 +1,9 @@
 --
--- Sequence "collected_contact_ids"
--- Name: collected_contact_ids; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Sequence "collected_contacts_seq"
+-- Name: collected_contacts_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE collected_contact_ids
+CREATE SEQUENCE collected_contacts_seq
     START WITH 1
     INCREMENT BY 1
     NO MAXVALUE
@@ -16,7 +16,7 @@ CREATE SEQUENCE collected_contact_ids
 --
 
 CREATE TABLE collected_contacts (
-    contact_id integer DEFAULT nextval('collected_contact_ids'::text) PRIMARY KEY,
+    contact_id integer DEFAULT nextval('collected_contacts_seq'::text) PRIMARY KEY,
     user_id integer NOT NULL
         REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
     changed timestamp with time zone DEFAULT now() NOT NULL,


### PR DESCRIPTION
Manual insertion of contact fails with _errorsavingcontact_ due to inability to get last contact_id, caused by inappropriate sequence name. The actual contact is saved correctly, though.

RC returns contact_id or FALSE as a result for insertion operation. Method _rcube_db_pgsql::insert_id()_ in _/program/lib/Roundcube/rcube_db_pgsql.php_ gets the value of last contact_id directly from sequence counter, thus it's internally calling _rcube_db_pgsql::sequence_name()_ method, which requires the sequence name in format &lt;table_name&gt;_seq (as explicitly written in the method's comment).
