### PR TITLE
Replace deprecated functions

### DIFF
--- a/automatic_addressbook.php
+++ b/automatic_addressbook.php
@@ -78,7 +78,7 @@ class automatic_addressbook extends rcube_plugin
         if ($rcmail->config->get('use_auto_abook', true)) {
             $p['sources'][$this->abook_id] = 
                 array('id' => $this->abook_id,
-                      'name' => Q($this->gettext('automaticallycollected')),
+                      'name' => rcube_utils::rep_specialchars_output($this->gettext('automaticallycollected')),
                       'readonly' => FALSE, 'groups' => false);
         }
 
@@ -214,7 +214,7 @@ class automatic_addressbook extends rcube_plugin
             ));
             $args['blocks']['automaticallycollected']['name'] = $this->gettext('automaticallycollected');
             $args['blocks']['automaticallycollected']['options']['use_subscriptions'] = array(
-                'title' => html::label($field_id, Q($this->gettext('useautoabook'))),
+                'title' => html::label($field_id, rcube_utils::rep_specialchars_output($this->gettext('useautoabook'))),
                 'content' => $checkbox->show($use_auto_abook ? 1 : 0),
             );
 
@@ -226,7 +226,7 @@ class automatic_addressbook extends rcube_plugin
                          ));
             $args['blocks']['automaticallycollected']['name'] = $this->gettext('automaticallycollected');
             $args['blocks']['automaticallycollected']['options']['use_autocompletion'] = array(
-                'title' => html::label($field_id2, Q($this->gettext('useforcompletion'))),
+                'title' => html::label($field_id2, rcube_utils::rep_specialchars_output($this->gettext('useforcompletion'))),
                 'content' => $checkbox2->show($use_auto_abook_for_completion ? 1 : 0),
             );
         }

--- a/automatic_addressbook_backend.php
+++ b/automatic_addressbook_backend.php
@@ -17,6 +17,6 @@ class automatic_addressbook_backend extends rcube_contacts
     function __construct($dbconn, $user)
     {
         parent::__construct($dbconn, $user);
-        $this->db_name = get_table_name('collected_contacts');
+        $this->db_name = rcmail::get_instance()->db->table_name('collected_contacts');
     }
 }


### PR DESCRIPTION
Fixes deprecation warnings in Roundcube 1.2-beta in accordance to [bc.php](https://github.com/roundcube/roundcubemail/blob/master/program/include/bc.php). (Retaining compatibility with versions 0.9+)

```
[05-Mar-2016 18:59:07 +0100]: <bcmhaqcm> Warning: Call to deprecated function Q(); See bc.inc for replacement
[05-Mar-2016 18:59:11 +0100]: <bcmhaqcm> Warning: Call to deprecated function get_table_name(); See bc.inc for replacement
```
