### PR TITLE
Check if DB table already exists before creating it

### DIFF
--- a/SQL/mssql.initial.sql
+++ b/SQL/mssql.initial.sql
@@ -1,4 +1,9 @@
-CREATE TABLE [dbo].[collected_contacts] (
+IF NOT EXISTS (
+        SELECT * FROM sys.tables t 
+        JOIN sys.schemas s ON (t.schema_id = s.schema_id) 
+        WHERE s.name = 'dbo' AND t.name = 'collected_contacts'
+        )
+        CREATE TABLE [dbo].[collected_contacts] (
         [contact_id] [int] IDENTITY (1, 1) NOT NULL ,
         [user_id] [int] NOT NULL , 
         [changed] [datetime] NOT NULL ,

--- a/SQL/mysql.initial.sql
+++ b/SQL/mysql.initial.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `collected_contacts` (
+CREATE TABLE IF NOT EXISTS `collected_contacts` (
  `contact_id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
  `changed` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
  `del` tinyint(1) NOT NULL DEFAULT '0',

--- a/SQL/postgres.initial.sql
+++ b/SQL/postgres.initial.sql
@@ -15,7 +15,7 @@ CREATE SEQUENCE collected_contacts_seq
 -- Name: collected_contacts; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE collected_contacts (
+CREATE TABLE IF NOT EXISTS collected_contacts (
     contact_id integer DEFAULT nextval('collected_contacts_seq'::text) PRIMARY KEY,
     user_id integer NOT NULL
         REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/SQL/sqlite.initial.sql
+++ b/SQL/sqlite.initial.sql
@@ -1,4 +1,4 @@
-CREATE TABLE collected_contacts (
+CREATE TABLE IF NOT EXISTS collected_contacts (
   contact_id integer NOT NULL PRIMARY KEY,
   user_id integer NOT NULL,
   changed datetime NOT NULL default '0000-00-00 00:00:00',


### PR DESCRIPTION
**Problem**
I have the following error from this plugin when I want to upgrade my Roundcube installation.

```
18459 INFO DEBUG - ERROR: [1050] Table 'collected_contacts' already exists
```
**Solution**
Added conditional checks to the SQL scripts that only create the table if it doesn't exist.
